### PR TITLE
Save a copy of scrapy cache on every run

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -24,6 +24,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true # https://github.com/aws/aws-cli/issues/5262
       run: |
         dvc repro
     - name: Update kaggle dataset

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ terraform.rc
 
 .ipynb_checkpoints
 .virtual_documents
+
+.scrapy

--- a/data/fetch_raw.sh
+++ b/data/fetch_raw.sh
@@ -1,6 +1,6 @@
 set -xe
 
-scraper_version=0.1.1
+scraper_version=v0.1.1
 
 leagues_file=$PWD/$1
 

--- a/dvc.lock
+++ b/dvc.lock
@@ -2,20 +2,20 @@ data_prep:
   cmd: (cd prep && python prep.py --raw-files-location ../data/raw && cp stage/* ../data/prep)
   deps:
   - path: data/raw/appearances.json
-    md5: fbc30020afacc5bbb8633fe8901e0dbf
-    size: 67092725
+    md5: ff9cc591c7c7f19070c765c96cc77bc4
+    size: 67219287
   - path: data/raw/clubs.json
-    md5: 421a91a7ff85006982b8bb0e213622d3
+    md5: 80643dea40e591c30faeec77e05d527a
     size: 38721
   - path: data/raw/leagues.json
     md5: 78ce56a97b1756568f64e5a29337ed3c
     size: 1922
   outs:
   - path: data/prep/appearances.csv
-    md5: af830347fb3e5729016444b238b3b147
-    size: 9038705
+    md5: eb3b1507df2225969678bbcab936a1ea
+    size: 9040458
   - path: data/prep/clubs.csv
-    md5: 084be1efe06d5aadefc0b3b40bb44257
+    md5: aa99e5ae0b6e8b3ab88580fd69d0f3ab
     size: 6493
   - path: data/prep/leagues.csv
     md5: b0b7855b8c39ed197af824de29df37b7

--- a/prep/assets/base.py
+++ b/prep/assets/base.py
@@ -1,11 +1,9 @@
-from frictionless import resource
 from frictionless import Detector
 from frictionless.resource import Resource
 from numpy.lib.function_base import select
 import pandas
 import numpy
 import json
-from typing import List
 from datetime import datetime, timedelta
 
 class BaseProcessor:
@@ -76,61 +74,6 @@ class BaseProcessor:
     resource.schema = self.resource_schema()
     return resource
 
-  def flatten(df: pandas.DataFrame, list_fields: List[str]) -> pandas.DataFrame:
-    """Flatten a dataframe on a 'list' type colum
-    Parameters:
-      df -> A pandas dataframe
-      list_fields -> A list of fields of type 'list'
-    """
-    
-    non_list_fileds = [column for column in df.columns if column not in list_fields]
-
-    df_as_json_lists_string = df.to_json(orient='records')
-    df_as_json_lists = json.loads(df_as_json_lists_string)
-
-    return pandas.json_normalize(
-      df_as_json_lists,
-      list_fields,
-      non_list_fileds
-    )
-
-  @classmethod
-  def renames(cls, df: pandas.DataFrame, mappings: dict) -> pandas.DataFrame:
-    return df.rename(
-      columns=mappings,
-      errors="raise"
-    )
-
-  @classmethod
-  def create_surrogate_key(cls, name: str, columns: List[str], df: pandas.DataFrame) -> pandas.DataFrame:
-    games_df = df.drop_duplicates(subset=columns).sort_values(
-      by=columns
-    )[columns]
-    games_df[name] = games_df.index.values + 1
-    return df.merge(
-      games_df,
-      on=columns
-    )
-
-  @classmethod
-  def parse_aggregate(cls, series: pandas.Series) -> pandas.DataFrame:
-    parsed = series.str.split(":", expand=True)
-    cols = ['home_club_goals', 'away_club_goals']
-    parsed.columns = cols
-    parsed[cols] = parsed[cols].astype('int32',errors='ignore')
-    return parsed
-
-  @classmethod
-  def infer_season(cls, series: pandas.Series) -> pandas.Series:
-    def infer_season(date: datetime):
-      year = date.year
-      month = date.month
-      if month >= 8 and month <= 12:
-        return year
-      if month >= 1 and month <8:
-        return year - 1
-
-    return series.apply(infer_season)
 
   def get_validations(self):
     pass


### PR DESCRIPTION
Push to a S3 a copy of scrapy cache after every run. This will enable historical backfilling if the site changes over time, and storing the `.json` semi-raw files  will no longer be necessary

~~**A new scraper release is necessary** for this changes to work (v0.1.1)~~