### PR TITLE
Use separate access token for 'on-schedule' workflow

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 4 * * TUE'
   workflow_dispatch:
+    inputs:
+      message:
+        required: false
+        default: ':wrench: Github Actions: Manually updated dataset files'
+        description: Commit message for the 'add-and-commit' step
 
 jobs:
   data-pipeline:
@@ -17,6 +22,10 @@ jobs:
     - run: |
         echo "${{ github.event.head_commit.message }}"
     - uses: actions/checkout@v2
+      # a different (personal access) github token need to be setup here so that a 'add-and-commit' step below triggers the 'on-push' workflow
+      # checkout https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
+      with:
+        github_token: ${{ secrets.PA_GITHUB_TOKEN}}
     - uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 6bd2f5d5de4743be1f8cca38cf629f70.dir
-  size: 79093548
+- md5: 0544a8c4a55a004f17864ae4f7820661.dir
+  size: 79092113
   nfiles: 6
   path: prep

--- a/prep/assets/clubs.py
+++ b/prep/assets/clubs.py
@@ -29,7 +29,6 @@ class ClubsProcessor(BaseProcessor):
     prep_df['domestic_competition'] = json_normalized['parent.href'].str.split('/', 5, True)[4]
     prep_df['league_id'] = league_href_parts[4]
     prep_df['total_market_value'] = pandas.to_numeric(json_normalized['total_market_value'])
-    prep_df['market_value_currency'] = "GBP"
     prep_df['squad_size'] = json_normalized['squad_size'].astype('int32')
     prep_df['average_age'] = pandas.to_numeric(json_normalized['average_age'])
     prep_df['foreigners_number'] = json_normalized['foreigners_number'].fillna(0).astype('int32')
@@ -74,8 +73,12 @@ class ClubsProcessor(BaseProcessor):
     self.schema.add_field(Field(name='pretty_name', type='string'))
     self.schema.add_field(Field(name='domestic_competition', type='string'))
     self.schema.add_field(Field(name='league_id', type='string'))
-    self.schema.add_field(Field(name='total_market_value', type='number'))
-    self.schema.add_field(Field(name='market_value_currency', type='string'))
+    self.schema.add_field(Field(
+        name='total_market_value',
+        type='number',
+        description="Aggregated players' Transfermarkt market value in millions of pounds"
+      )
+    )
     self.schema.add_field(Field(name='squad_size', type='integer'))
     self.schema.add_field(Field(name='average_age', type='number'))
     self.schema.add_field(Field(name='foreigners_number', type='integer'))


### PR DESCRIPTION
a different (personal access) github token need to be setup here so that a 'add-and-commit' step below triggers the 'on-push' workflow

checkout https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854

Bonus: remove useless column in clubs