### PR TITLE
Enable self-serve DVC backend access granting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+*.lock.hcl
+
 # Ignore PyCharm
 .idea
 

--- a/infra/base/main.tf
+++ b/infra/base/main.tf
@@ -92,6 +92,8 @@ resource "aws_s3_bucket_policy" "bucket_policy_base" {
 resource "aws_s3_bucket_policy" "bucket_policy_process" {
   bucket = aws_s3_bucket.bucket.id
   policy = data.aws_iam_policy_document.user_access_process.json
+
+  depends_on = [aws_s3_bucket_policy.bucket_policy_base]
 }
 
 output "process_user_arn" {

--- a/infra/base/main.tf
+++ b/infra/base/main.tf
@@ -11,12 +11,14 @@ resource "aws_iam_user" "user" {
 }
 
 # create a limited access policy for the project user
-data "aws_iam_policy_document" "user_access" {
+data "aws_iam_policy_document" "user_access_base" {
+  for_each = toset(var.authorized_users)
+
   statement {
     sid = "bucket-level"
     principals {
       type = "AWS"
-      identifiers = [aws_iam_user.user.arn]
+      identifiers = [each.key]
     }
     actions = [
       "s3:GetBucketLocation",
@@ -29,21 +31,40 @@ data "aws_iam_policy_document" "user_access" {
   }
 
   statement {
-    sid = "read-write"
+    sid = "read-dvc"
     principals {
       type = "AWS"
       identifiers = [aws_iam_user.user.arn]
     }
     actions = [
-      "s3:GetObject",
-      "s3:PutObject"
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.bucket.arn}/dvc/*",
+    ]
+  } 
+  
+  
+}
+
+data "aws_iam_policy_document" "user_access_process" {
+  statement {
+    sid = "write-dvc"
+    principals {
+      type = "AWS"
+      identifiers = [aws_iam_user.user.arn]
+    }
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject"
     ]
 
     resources = [
       "${aws_s3_bucket.bucket.arn}/*",
     ]
-  } 
-  
+  }
+
   statement {
     sid = "delete"
     principals {
@@ -61,7 +82,18 @@ data "aws_iam_policy_document" "user_access" {
 }
 
 # attach policy to the bucket
-resource "aws_s3_bucket_policy" "bucket_policy" {
+resource "aws_s3_bucket_policy" "bucket_policy_base" {
+  for_each = toset([for s in data.aws_iam_policy_document.user_access_base : s.json])
+
   bucket = aws_s3_bucket.bucket.id
-  policy = data.aws_iam_policy_document.user_access.json
+  policy = each.key
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy_process" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.user_access_process.json
+}
+
+output "process_user_arn" {
+  value = aws_iam_user.user.arn
 }

--- a/infra/base/variables.tf
+++ b/infra/base/variables.tf
@@ -8,6 +8,12 @@ variable "user_name" {
   description = "The name of the user for the project"
 }
 
+variable "authorized_users" {
+  type = list(string)
+  description = "IAM users who are authorized to read dvc/ objects"
+  default = []
+}
+
 variable "tags" {
   type = map
   description = "Project tags"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "3.24.1"
+      version = "3.52.0"
     }
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -15,6 +15,9 @@ module "base" {
   source = "./base"
   bucket_name = "player-scores"
   user_name = "player-scores"
+  authorized_users = [
+    "arn:aws:iam::272181418418:user/player-scores"
+  ]
   tags = {
     "project" = "player-scores"
   }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -11,13 +11,17 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# add your AWS IAM user ARN to this list to gain access to DVC remote storage
+locals {
+  authorized_users = [
+    "arn:aws:iam::272181418418:user/player-scores"
+  ]
+}
 module "base" {
   source = "./base"
   bucket_name = "player-scores"
   user_name = "player-scores"
-  authorized_users = [
-    "arn:aws:iam::272181418418:user/player-scores"
-  ]
+  authorized_users = local.authorized_users
   tags = {
     "project" = "player-scores"
   }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,7 +14,6 @@ provider "aws" {
 # add your AWS IAM user ARN to this list to gain access to DVC remote storage
 locals {
   authorized_users = [
-    "arn:aws:iam::272181418418:user/player-scores"
   ]
 }
 module "base" {


### PR DESCRIPTION
In order to be able to pull data from DVC remote storage, potential contributors need to be able to List and Get objects from S3 bucket s3://player-scores. Enable users to self-grant permissions for this actions by creating a PR adding their IAM user to a whitelist in the Terraform configuration.

- [X] Access to DVC remote storage can be self-defined by adding the IAM user are to the the `base` module argument `authorized_users`
- [x] Fix `An error occurred (AccessDenied) when calling the ListObjects operation: Access Denied` issue
- [ ] ~~Process to self-grant access to an IAM user documented~~ To be done on a separe PR

Closes #44 