### PR TITLE
Add `player-scores` IAM user ARN to DVC whitelist

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,6 +14,7 @@ provider "aws" {
 # add your AWS IAM user ARN to this list to gain access to DVC remote storage
 locals {
   authorized_users = [
+    "arn:aws:iam::272181418418:user/player-scores"
   ]
 }
 module "base" {


### PR DESCRIPTION
This PR adds the project IAM process user ARN to the list of ARNs whitelisted for DVC access (read and list).

This PR may be used as reference for granting access to DVC to other IAM users. Self-serve access to the DVC remote storage for this project by creating an analogous PR, adding the ARN of your users to the `authorized_users` list.